### PR TITLE
Optionally export background layer, fix convert, restore layer transparency after export

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Please, refer to 'howto' files ( PDFs ) for help.
 Installation:
 copy all files into you Inkscape extension folder ( .config/inkscape/extensions for Linux ).
 
+Known Issue:
+- Animation names may not contain any underscores. Could be solved by either auto-replacing, not allowing to create an animation with such a name, or by fixing the code to not split on all, but only on the last underscore.
+- Gif animations are rather large, could be made smaller using gifsicle (as an optional dependency)
+

--- a/iaps_exanim.inx
+++ b/iaps_exanim.inx
@@ -9,6 +9,7 @@
 	<param name="frameh" type="int" min="1" max="1024"  _gui-text="Frame height, px">320</param>
 	<param name="path" type="string"  _gui-text="export directory path">.</param>
 	<param name="gif" type="boolean" _gui-text="also make GIF">true</param>
+        <param name="export_bg" type="boolean" _gui-text="Export background">true</param>
 	<param name="rate" type="int" min="1" max="5000" _gui-text="GIF framerate,ms">100</param>
 	<param name="debug" type="boolean" _gui-text="Make log">true</param>
 

--- a/iaps_exanim.py
+++ b/iaps_exanim.py
@@ -15,6 +15,7 @@ class IAPS_ExportAnim( inkex.Effect ):
 		self.OptionParser.add_option("--path",action="store",type="string",dest="path",default=".",help="")
 		self.OptionParser.add_option("--gif",action="store",type="inkbool",dest="make_gif",default="True",help="")
 		self.OptionParser.add_option("--rate",action="store",type="int",dest="gif_rate",default="50",help="")
+		self.OptionParser.add_option("--export_bg",action="store",type="inkbool",dest="export_bg",default="True",help="")
 		# debug mode 
 		self.OptionParser.add_option("--debug",action="store",type="inkbool",dest="debug",default="False",help="")
 
@@ -26,8 +27,9 @@ class IAPS_ExportAnim( inkex.Effect ):
 		path = self.options.path
 		make_gif = self.options.make_gif
 		gif_rate = self.options.gif_rate
+		export_bg = self.options.export_bg
 		# export using AnimationExport class
-		a = AnimationExport( self, self.current_layer, path, make_gif, gif_rate, frame_w, frame_h, use_frame_wh, self.options.debug )
+		a = AnimationExport( self, self.current_layer, path, make_gif, gif_rate, frame_w, frame_h, use_frame_wh, export_bg, self.options.debug )
 		a.export()
 
 def _main():


### PR DESCRIPTION
Hi @ray-hplus ,

Thanks for this fun piece of software!

I've edited the animation extension so that it will export a working gif file again, even with > 9 layers.
It also now has an option to export the background layer, and it automatically restores the layer transparencies after exporting, so the onion-skinning still works after first export.

I'd like to ask you about licencing, as I cannot find any licence info. Would you make this extension available for use/distribution with Inkscape by using GPLv2+ ?

If so, I can add the licence in for you ;-)

Also, I would like to ask you if you would like to upload your extension to inkscape.org, so more people can know about it. We've got an extension gallery at the website now: 
https://inkscape.org/en/download/addons/

Kind Regards,
 Moini

(Proof attached ;-) )

![sheep](https://cloud.githubusercontent.com/assets/3240233/15988257/e4cc89e6-3048-11e6-9337-c2477652e433.gif)